### PR TITLE
removed '-fixed' from default options for ifort flags 

### DIFF
--- a/configure
+++ b/configure
@@ -2194,7 +2194,7 @@ case "${FC}" in
       ;;
     ifort)
       echo "  R configured for Intel fortran..."
-      OUR_FCFLAGS="-O3 -axsse4.2 -r8 -fpp -fixed"
+      OUR_FCFLAGS="-O3 -axsse4.2 -r8 -fpp"
 
       ;;
     *)

--- a/configure.in
+++ b/configure.in
@@ -30,7 +30,7 @@ case "${FC}" in
       ;;
     ifort)
       echo "  R configured for Intel fortran..."
-      AC_SUBST(OUR_FCFLAGS, "-O3 -axsse4.2 -r8 -fpp -fixed")
+      AC_SUBST(OUR_FCFLAGS, "-O3 -axsse4.2 -r8 -fpp")
       ;;
     *)
       echo "    Unsupported Fortran 90 compiler or Fortran 90"


### PR DESCRIPTION
source code lines over 72 characters in length causes compilation errors
